### PR TITLE
display commits that are going to go out with the deploy

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -197,6 +197,8 @@ func RunDeploy(c *cli.Context) error {
 }
 
 func displayNewCommits(owner string, repo string, c *cli.Context, client *github.Client) {
+	ref := Ref(c.String("ref"), git.Head)
+
 	opt := &github.DeploymentsListOptions{
 		Environment: c.String("env"),
 	}
@@ -204,14 +206,14 @@ func displayNewCommits(owner string, repo string, c *cli.Context, client *github
 	deployments, _, error := client.Repositories.ListDeployments(owner, repo, opt)
 	if error == nil {
 		sha := *deployments[0].SHA
-		compare, _, cmp_error := client.Repositories.CompareCommits(owner, repo, sha, "master")
+		compare, _, cmp_error := client.Repositories.CompareCommits(owner, repo, sha, ref)
 		if cmp_error == nil && len(compare.Commits) > 0 {
 			fmt.Println("Deploying the following commits:\n")
 			for _, commit := range compare.Commits {
 				message := *commit.Commit.Message
 				fmt.Printf("%-20s\t%s\n", *commit.Commit.Author.Name, strings.Split(message, "\n")[0])
 			}
-			fmt.Printf("\nSee entire diff here: https://github.com/%s/%s/compare/%s...master\n\n", owner, repo, sha)
+			fmt.Printf("\nSee entire diff here: https://github.com/%s/%s/compare/%s...%s\n\n", owner, repo, sha, ref)
 		}
         }
 }

--- a/deploy.go
+++ b/deploy.go
@@ -147,7 +147,10 @@ func RunDeploy(c *cli.Context) error {
 		return fmt.Errorf("Invalid GitHub repo: %s", nwo)
 	}
 
-	displayNewCommits(owner, repo, c, client)
+	err = displayNewCommits(owner, repo, c, client)
+	if err != nil {
+		return err
+	}
 
 	r, err := newDeploymentRequest(c)
 	if err != nil {
@@ -196,26 +199,31 @@ func RunDeploy(c *cli.Context) error {
 	return nil
 }
 
-func displayNewCommits(owner string, repo string, c *cli.Context, client *github.Client) {
+func displayNewCommits(owner string, repo string, c *cli.Context, client *github.Client) error {
 	ref := Ref(c.String("ref"), git.Head)
 
 	opt := &github.DeploymentsListOptions{
 		Environment: c.String("env"),
 	}
 
-	deployments, _, error := client.Repositories.ListDeployments(owner, repo, opt)
-	if error == nil {
-		sha := *deployments[0].SHA
-		compare, _, cmp_error := client.Repositories.CompareCommits(owner, repo, sha, ref)
-		if cmp_error == nil && len(compare.Commits) > 0 {
-			fmt.Println("Deploying the following commits:\n")
-			for _, commit := range compare.Commits {
-				message := *commit.Commit.Message
-				fmt.Printf("%-20s\t%s\n", *commit.Commit.Author.Name, strings.Split(message, "\n")[0])
-			}
-			fmt.Printf("\nSee entire diff here: https://github.com/%s/%s/compare/%s...%s\n\n", owner, repo, sha, ref)
-		}
-        }
+	deployments, _, err := client.Repositories.ListDeployments(owner, repo, opt)
+	if err != nil || len(deployments) == 0 {
+		return err
+	}
+
+	sha := *deployments[0].SHA
+	compare, _, err := client.Repositories.CompareCommits(owner, repo, sha, ref)
+	if err != nil || len(compare.Commits) == 0 {
+		return err
+	}
+
+	fmt.Println("Deploying the following commits:\n")
+	for _, commit := range compare.Commits {
+		message := *commit.Commit.Message
+		fmt.Printf("%-20s\t%s\n", *commit.Commit.Author.Name, strings.Split(message, "\n")[0])
+	}
+	fmt.Printf("\nSee entire diff here: https://github.com/%s/%s/compare/%s...%s\n\n", owner, repo, sha, ref)
+	return nil
 }
 
 func newDeploymentRequest(c *cli.Context) (*github.DeploymentRequest, error) {


### PR DESCRIPTION
Adds some output when running to deploy to let you know what you're pushing. Also links to the github compare page so you can see a code diff. Resolves #26. Example output: https://gist.github.com/gauravmk/6c48606e0dfc1d6db05c
