### PR TITLE
clean up error handling code to be clearer

### DIFF
--- a/deploy.go
+++ b/deploy.go
@@ -207,14 +207,18 @@ func displayNewCommits(owner string, repo string, c *cli.Context, client *github
 	}
 
 	deployments, _, err := client.Repositories.ListDeployments(owner, repo, opt)
-	if err != nil || len(deployments) == 0 {
+	if err != nil {
 		return err
+	} else if len(deployments) == 0 {
+		return nil
 	}
 
 	sha := *deployments[0].SHA
 	compare, _, err := client.Repositories.CompareCommits(owner, repo, sha, ref)
-	if err != nil || len(compare.Commits) == 0 {
+	if err != nil {
 		return err
+	} else if len(compare.Commits) == 0 {
+		return nil
 	}
 
 	fmt.Println("Deploying the following commits:\n")

--- a/deploy.go
+++ b/deploy.go
@@ -209,7 +209,8 @@ func displayNewCommits(owner string, repo string, c *cli.Context, client *github
 	deployments, _, err := client.Repositories.ListDeployments(owner, repo, opt)
 	if err != nil {
 		return err
-	} else if len(deployments) == 0 {
+	}
+	if len(deployments) == 0 {
 		return nil
 	}
 
@@ -217,7 +218,8 @@ func displayNewCommits(owner string, repo string, c *cli.Context, client *github
 	compare, _, err := client.Repositories.CompareCommits(owner, repo, sha, ref)
 	if err != nil {
 		return err
-	} else if len(compare.Commits) == 0 {
+	}
+	if len(compare.Commits) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
we're not throwing an error if `len(deployments) == 0 || len(commits) == 0` so we shouldn't have the code look like that's what it's doing
